### PR TITLE
Bugfix for hashed byte reads

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "0.0.4"
+	version = "0.0.5"
 )
 
 var (


### PR DESCRIPTION
HashedBlock reads were not appending to data results when file buffer
was surpassing byteChunks value. Updated to append slice to result slice directly.